### PR TITLE
Return null when no BIOS UUID is present

### DIFF
--- a/vmbk/src/com/vmware/vmbk/util/Utility.java
+++ b/vmbk/src/com/vmware/vmbk/util/Utility.java
@@ -214,7 +214,7 @@ public class Utility {
 	    }
 	} catch (final Exception ex) {
 	    System.err.println("Linux UUID Exp : " + ex.getMessage());
-	    return "......";
+	    return null;
 
 	}
 


### PR DESCRIPTION
On Windows Subsystem for Linux 2 (WSL2), the `dmidecode` command doesn't return anything.   The safekeeper CLI will proceed if this return value is null, but otherwise will error out with

```
Safekeeping Version 1.0.1 - VDDK Version 7.0.0
Linux UUID Exp : null
Server: DESKTOP-PH7B5L7 ip:127.0.1.1 uuid:......
java.lang.StringIndexOutOfBoundsException: String index out of range: 6
        at java.lang.String.charAt(String.java:658)
        at com.vmware.vmbk.util.Utility.toBigEndianUuid(Utility.java:317)
        at com.vmware.vmbk.util.BiosUuid.getLocalHwSettings(BiosUuid.java:76)
        at com.vmware.vmbkCmd.command.VersionCommandInteractive.showVersion(VersionCommandInteractive.java:55)
        at com.vmware.vmbkCmd.VmbkMain.initialize(VmbkMain.java:295)
        at com.vmware.vmbkCmd.VmbkMain.main(VmbkMain.java:97)
```